### PR TITLE
Add postcss and postcss-syntax to dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,55 +1,55 @@
 {
   "name": "@asl-19/stylelint-config",
-  "version": "0.3.0",
+  "version": "0.4.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@asl-19/stylelint-config",
-      "version": "0.3.0",
+      "version": "0.4.1",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@stylelint/postcss-css-in-js": "^0.37.2",
+        "postcss": "^8.4.5",
+        "postcss-syntax": "^0.36.2",
         "stylelint-config-prettier": "^9.0.3",
-        "stylelint-config-standard": "^23.0.0",
+        "stylelint-config-standard": "^24.0.0",
         "stylelint-order": "^5.0.0"
       },
       "devDependencies": {
-        "@asl-19/eslint-config": "^0.4.0",
-        "@types/node": "^16.11.6",
+        "@asl-19/eslint-config": "^0.5.0",
+        "@types/node": "^16.11.17",
         "eslint": "^7.32.0",
-        "prettier": "^2.4.1"
+        "prettier": "^2.5.1"
       },
       "peerDependencies": {
-        "stylelint": "^14.0.1"
+        "stylelint": "^14.2.0"
       }
     },
     "node_modules/@asl-19/eslint-config": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@asl-19/eslint-config/-/eslint-config-0.4.0.tgz",
-      "integrity": "sha512-+IY12tLwTGL0G8LNXAcZcLCkDw7FcySktONDLjBVG6uaVTPOBR+N2V5uA/Dvw2Mi//DVeTdpIV11jE1SXR1YWw==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@asl-19/eslint-config/-/eslint-config-0.5.0.tgz",
+      "integrity": "sha512-ekGKo66xwLA4nHGGf73aotJJl/eHaiEKnmUt1UtjJsxpsEZS5d9j4Nj16e9rVaxN/YTfoOR3D6lb8nt8QaqUDg==",
       "dev": true,
       "dependencies": {
-        "@emotion/eslint-plugin": "^11.2.0",
-        "@rushstack/eslint-config": "^2.3.2",
-        "@rushstack/eslint-patch": "^1.0.6",
-        "eslint-config-prettier": "^8.1.0",
-        "eslint-import-resolver-typescript": "^2.4.0",
-        "eslint-plugin-functional": "^3.2.1",
-        "eslint-plugin-import": "^2.22.1",
+        "@emotion/eslint-plugin": "^11.5.0",
+        "@mizdra/eslint-plugin-layout-shift": "^1.0.1",
+        "@next/eslint-plugin-next": "^12.0.2",
+        "@rushstack/eslint-config": "^2.4.4",
+        "@rushstack/eslint-patch": "^1.0.9",
+        "eslint-config-prettier": "^8.3.0",
+        "eslint-import-resolver-typescript": "^2.5.0",
+        "eslint-plugin-functional": "^3.7.2",
+        "eslint-plugin-import": "^2.25.2",
         "eslint-plugin-jsx-a11y": "^6.4.1",
-        "eslint-plugin-prettier": "^3.3.1",
+        "eslint-plugin-prettier": "^4.0.0",
         "eslint-plugin-react-hooks": "^4.2.0",
         "eslint-plugin-simple-import-sort": "^7.0.0",
-        "eslint-plugin-sort-destructure-keys": "^1.3.4"
-      },
-      "engines": {
-        "node": ">= 12"
+        "eslint-plugin-sort-destructure-keys": "^1.4.0"
       },
       "peerDependencies": {
-        "eslint": "^7.22.0",
-        "prettier": "^2.2.1",
-        "typescript": "^4.2.3"
+        "eslint": "^7.32.0",
+        "prettier": "^2.4.1"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -484,6 +484,63 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/@mizdra/eslint-plugin-layout-shift": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@mizdra/eslint-plugin-layout-shift/-/eslint-plugin-layout-shift-1.0.1.tgz",
+      "integrity": "sha512-rms2HZUp5BUwJJ+w3YEiyi4Vrcc2x0L+Yg1HWOGCoc/FM3VMgeE3fF22Gs+E6dxiskPn9QgcoNOJDqdAmlRSgg==",
+      "dev": true,
+      "dependencies": {
+        "jsx-ast-utils": "^2.4.1"
+      },
+      "engines": {
+        "node": ">=10.0"
+      },
+      "peerDependencies": {
+        "eslint": ">=3.0"
+      }
+    },
+    "node_modules/@mizdra/eslint-plugin-layout-shift/node_modules/jsx-ast-utils": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-2.4.1.tgz",
+      "integrity": "sha512-z1xSldJ6imESSzOjd3NNkieVJKRlKYSOtMG8SFyCj2FIrvSaSuli/WjpBkEzCBoR9bYYYFgqJw61Xhu7Lcgk+w==",
+      "dev": true,
+      "dependencies": {
+        "array-includes": "^3.1.1",
+        "object.assign": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/@next/eslint-plugin-next": {
+      "version": "12.0.7",
+      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-12.0.7.tgz",
+      "integrity": "sha512-xk7eMjw4+roWWR/0ETIoToCNs2wdvCGgQUiUO390Rj33/82yxZsh+ODRSaFWkiKp8zHWQN5GCW+U5pfjt/gyQg==",
+      "dev": true,
+      "dependencies": {
+        "glob": "7.1.7"
+      }
+    },
+    "node_modules/@next/eslint-plugin-next/node_modules/glob": {
+      "version": "7.1.7",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
+      "integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
+      "dev": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -621,9 +678,9 @@
       "peer": true
     },
     "node_modules/@types/node": {
-      "version": "16.11.6",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.6.tgz",
-      "integrity": "sha512-ua7PgUoeQFjmWPcoo9khiPum3Pd60k4/2ZGXt18sm2Slk0W0xZTqt5Y0Ny1NyBiN1EVQ/+FaF9NcY4Qe6rwk5w==",
+      "version": "16.11.17",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.17.tgz",
+      "integrity": "sha512-C1vTZME8cFo8uxY2ui41xcynEotVkczIVI5AjLmy5pkpBv/FtG+jhtOlfcPysI8VRVwoOMv6NJm44LGnoMSWkw==",
       "dev": true
     },
     "node_modules/@types/normalize-package-data": {
@@ -1169,6 +1226,12 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
     },
+    "node_modules/colord": {
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/colord/-/colord-2.9.2.tgz",
+      "integrity": "sha512-Uqbg+J445nc1TKn4FoDPS6ZZqAvEDnwrH42yo8B40JSOgSLxMZ/gt3h4nmCtPLQeXhjJJkqBx7SCY35WnIixaQ==",
+      "peer": true
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -1242,9 +1305,9 @@
       "dev": true
     },
     "node_modules/debug": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
-      "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
+      "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
       "dependencies": {
         "ms": "2.1.2"
       },
@@ -1689,9 +1752,9 @@
       }
     },
     "node_modules/eslint-plugin-prettier": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-3.4.1.tgz",
-      "integrity": "sha512-htg25EUYUeIhKHXjOinK4BgCcDwtLHjqaxCDsMy5nbnUMkKFvIhMVCp+5GFUXQ4Nr8lBsPqtGAqBenbpFqAA2g==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-4.0.0.tgz",
+      "integrity": "sha512-98MqmCJ7vJodoQK359bqQWaxOE0CS8paAz/GgjaZLyex4TTk3g9HugoO89EqWCrFiOqn9EVvcoo7gZzONCWVwQ==",
       "dev": true,
       "dependencies": {
         "prettier-linter-helpers": "^1.0.0"
@@ -1700,8 +1763,8 @@
         "node": ">=6.0.0"
       },
       "peerDependencies": {
-        "eslint": ">=5.0.0",
-        "prettier": ">=1.13.0"
+        "eslint": ">=7.28.0",
+        "prettier": ">=2.0.0"
       },
       "peerDependenciesMeta": {
         "eslint-config-prettier": {
@@ -2877,9 +2940,9 @@
       }
     },
     "node_modules/known-css-properties": {
-      "version": "0.23.0",
-      "resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.23.0.tgz",
-      "integrity": "sha512-h9ivI88e1lFNmTT4HovBN33Ysn0OIJG7IPG2mkpx2uniQXFWqo35QdiX7w0TovlUFXfW8aPFblP5/q0jlOr2sA==",
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.24.0.tgz",
+      "integrity": "sha512-RTSoaUAfLvpR357vWzAz/50Q/BmHfmE6ETSWfutT0AJiw10e6CmcdYRQJlLRd95B53D0Y2aD1jSxD3V3ySF+PA==",
       "peer": true
     },
     "node_modules/language-subtag-registry": {
@@ -2928,11 +2991,6 @@
       "engines": {
         "node": ">=4"
       }
-    },
-    "node_modules/lodash.clonedeep": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
-      "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8="
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
@@ -3401,13 +3459,13 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.3.11",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.3.11.tgz",
-      "integrity": "sha512-hCmlUAIlUiav8Xdqw3Io4LcpA1DOt7h3LSTAC4G6JGHFFaWzI6qvFt9oilvl8BmkbBRX1IhM90ZAmpk68zccQA==",
+      "version": "8.4.5",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.5.tgz",
+      "integrity": "sha512-jBDboWM8qpaqwkMwItqTQTiFikhs/67OYVvblFFTM7MrZjt6yMKd6r2kgXizEbTTljacm4NldIlZnhbjr84QYg==",
       "dependencies": {
         "nanoid": "^3.1.30",
         "picocolors": "^1.0.0",
-        "source-map-js": "^0.6.2"
+        "source-map-js": "^1.0.1"
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
@@ -3446,9 +3504,9 @@
       }
     },
     "node_modules/postcss-selector-parser": {
-      "version": "6.0.6",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.6.tgz",
-      "integrity": "sha512-9LXrvaaX3+mcv5xkg5kFwqSzSH1JIObIx51PrndZwlmznwXRfxMddDvo9gve3gVR8ZTKgoFDdWkbRFmEhT4PMg==",
+      "version": "6.0.8",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.8.tgz",
+      "integrity": "sha512-D5PG53d209Z1Uhcc0qAZ5U3t5HagH3cxu+WLZ22jt3gLUpXM4eXXfiO14jiDWST3NNooX/E8wISfOhZ9eIjGTQ==",
       "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
@@ -3470,7 +3528,6 @@
       "version": "0.36.2",
       "resolved": "https://registry.npmjs.org/postcss-syntax/-/postcss-syntax-0.36.2.tgz",
       "integrity": "sha512-nBRg/i7E3SOHWxF3PpF5WnJM/jQ1YpY9000OaVXlAQj6Zp/kIqJxEDWIZ67tAd7NLuk7zqN4yqe9nc0oNAOs1w==",
-      "peer": true,
       "peerDependencies": {
         "postcss": ">=5.0.0"
       }
@@ -3491,9 +3548,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.4.1.tgz",
-      "integrity": "sha512-9fbDAXSBcc6Bs1mZrDYb3XKzDLm4EXXL9sC1LqKP5rZkT6KRr/rf9amVUcODVXgguK/isJz0d0hP72WeaKWsvA==",
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.5.1.tgz",
+      "integrity": "sha512-vBZcPRUR5MZJwoyi3ZoyQlc1rXeEck8KgeC9AwwOn+exuxLxq5toTRDTSaVrXHxelDMHy9zlicw8u66yxoSUFg==",
       "dev": true,
       "bin": {
         "prettier": "bin-prettier.js"
@@ -3960,9 +4017,9 @@
       }
     },
     "node_modules/source-map-js": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-0.6.2.tgz",
-      "integrity": "sha512-/3GptzWzu0+0MBQFrDKzw/DvvMTUORvgY6k6jd/VS6iCR4RDTKWH6v6WPwQoUO8667uQEf9Oe38DxAYWY5F/Ug==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.1.tgz",
+      "integrity": "sha512-4+TN2b3tqOCd/kaGRJ/sTYA0tR0mdXx26ipdolxcwtJVqEnqNYvlCAt1q3ypy4QMlYus+Zh34RNtYLoq2oQ4IA==",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -4128,14 +4185,15 @@
       "peer": true
     },
     "node_modules/stylelint": {
-      "version": "14.0.1",
-      "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-14.0.1.tgz",
-      "integrity": "sha512-ZcAkmFLVCultmwkQUjxKzxW/o5+CzNmDk6TPJj/d4Y7ipTGGrewIWmNm+InjdSr04PR5/yynsAJeYJY/wisdMg==",
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-14.2.0.tgz",
+      "integrity": "sha512-i0DrmDXFNpDsWiwx6SPRs4/pyw4kvZgqpDGvsTslQMY7hpUl6r33aQvNSn6cnTg2wtZ9rreFElI7XAKpOWi1vQ==",
       "peer": true,
       "dependencies": {
         "balanced-match": "^2.0.0",
+        "colord": "^2.9.2",
         "cosmiconfig": "^7.0.1",
-        "debug": "^4.3.2",
+        "debug": "^4.3.3",
         "execall": "^2.0.0",
         "fast-glob": "^3.2.7",
         "fastest-levenshtein": "^1.0.12",
@@ -4145,11 +4203,11 @@
         "globby": "^11.0.4",
         "globjoin": "^0.1.4",
         "html-tags": "^3.1.0",
-        "ignore": "^5.1.8",
+        "ignore": "^5.2.0",
         "import-lazy": "^4.0.0",
         "imurmurhash": "^0.1.4",
         "is-plain-object": "^5.0.0",
-        "known-css-properties": "^0.23.0",
+        "known-css-properties": "^0.24.0",
         "mathml-tag-names": "^2.1.3",
         "meow": "^9.0.0",
         "micromatch": "^4.0.4",
@@ -4160,7 +4218,7 @@
         "postcss-media-query-parser": "^0.2.3",
         "postcss-resolve-nested-selector": "^0.1.1",
         "postcss-safe-parser": "^6.0.0",
-        "postcss-selector-parser": "^6.0.6",
+        "postcss-selector-parser": "^6.0.7",
         "postcss-value-parser": "^4.1.0",
         "resolve-from": "^5.0.0",
         "specificity": "^0.4.1",
@@ -4168,7 +4226,7 @@
         "strip-ansi": "^6.0.1",
         "style-search": "^0.1.0",
         "svg-tags": "^1.0.0",
-        "table": "^6.7.2",
+        "table": "^6.7.5",
         "v8-compile-cache": "^2.3.0",
         "write-file-atomic": "^3.0.3"
       },
@@ -4207,9 +4265,9 @@
       }
     },
     "node_modules/stylelint-config-standard": {
-      "version": "23.0.0",
-      "resolved": "https://registry.npmjs.org/stylelint-config-standard/-/stylelint-config-standard-23.0.0.tgz",
-      "integrity": "sha512-8PDlk+nWuc1T66nVaODTdVodN0pjuE5TBlopi39Lt9EM36YJsRhqttMyUhnS78oc/59Q6n8iw2GJB4QcoFqtRg==",
+      "version": "24.0.0",
+      "resolved": "https://registry.npmjs.org/stylelint-config-standard/-/stylelint-config-standard-24.0.0.tgz",
+      "integrity": "sha512-+RtU7fbNT+VlNbdXJvnjc3USNPZRiRVp/d2DxOF/vBDDTi0kH5RX2Ny6errdtZJH3boO+bmqIYEllEmok4jiuw==",
       "dependencies": {
         "stylelint-config-recommended": "^6.0.0"
       },
@@ -4236,9 +4294,9 @@
       "peer": true
     },
     "node_modules/stylelint/node_modules/ignore": {
-      "version": "5.1.8",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
-      "integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
+      "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
       "peer": true,
       "engines": {
         "node": ">= 4"
@@ -4271,12 +4329,11 @@
       "peer": true
     },
     "node_modules/table": {
-      "version": "6.7.2",
-      "resolved": "https://registry.npmjs.org/table/-/table-6.7.2.tgz",
-      "integrity": "sha512-UFZK67uvyNivLeQbVtkiUs8Uuuxv24aSL4/Vil2PJVtMgU8Lx0CYkP12uCGa3kjyQzOSgV1+z9Wkb82fCGsO0g==",
+      "version": "6.7.5",
+      "resolved": "https://registry.npmjs.org/table/-/table-6.7.5.tgz",
+      "integrity": "sha512-LFNeryOqiQHqCVKzhkymKwt6ozeRhlm8IL1mE8rNUurkir4heF6PzMyRgaTa4tlyPTGGgXuvVOF/OLWiH09Lqw==",
       "dependencies": {
         "ajv": "^8.0.1",
-        "lodash.clonedeep": "^4.5.0",
         "lodash.truncate": "^4.4.2",
         "slice-ansi": "^4.0.0",
         "string-width": "^4.2.3",
@@ -4559,23 +4616,25 @@
   },
   "dependencies": {
     "@asl-19/eslint-config": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@asl-19/eslint-config/-/eslint-config-0.4.0.tgz",
-      "integrity": "sha512-+IY12tLwTGL0G8LNXAcZcLCkDw7FcySktONDLjBVG6uaVTPOBR+N2V5uA/Dvw2Mi//DVeTdpIV11jE1SXR1YWw==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@asl-19/eslint-config/-/eslint-config-0.5.0.tgz",
+      "integrity": "sha512-ekGKo66xwLA4nHGGf73aotJJl/eHaiEKnmUt1UtjJsxpsEZS5d9j4Nj16e9rVaxN/YTfoOR3D6lb8nt8QaqUDg==",
       "dev": true,
       "requires": {
-        "@emotion/eslint-plugin": "^11.2.0",
-        "@rushstack/eslint-config": "^2.3.2",
-        "@rushstack/eslint-patch": "^1.0.6",
-        "eslint-config-prettier": "^8.1.0",
-        "eslint-import-resolver-typescript": "^2.4.0",
-        "eslint-plugin-functional": "^3.2.1",
-        "eslint-plugin-import": "^2.22.1",
+        "@emotion/eslint-plugin": "^11.5.0",
+        "@mizdra/eslint-plugin-layout-shift": "^1.0.1",
+        "@next/eslint-plugin-next": "^12.0.2",
+        "@rushstack/eslint-config": "^2.4.4",
+        "@rushstack/eslint-patch": "^1.0.9",
+        "eslint-config-prettier": "^8.3.0",
+        "eslint-import-resolver-typescript": "^2.5.0",
+        "eslint-plugin-functional": "^3.7.2",
+        "eslint-plugin-import": "^2.25.2",
         "eslint-plugin-jsx-a11y": "^6.4.1",
-        "eslint-plugin-prettier": "^3.3.1",
+        "eslint-plugin-prettier": "^4.0.0",
         "eslint-plugin-react-hooks": "^4.2.0",
         "eslint-plugin-simple-import-sort": "^7.0.0",
-        "eslint-plugin-sort-destructure-keys": "^1.3.4"
+        "eslint-plugin-sort-destructure-keys": "^1.4.0"
       }
     },
     "@babel/code-frame": {
@@ -4903,6 +4962,52 @@
         }
       }
     },
+    "@mizdra/eslint-plugin-layout-shift": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@mizdra/eslint-plugin-layout-shift/-/eslint-plugin-layout-shift-1.0.1.tgz",
+      "integrity": "sha512-rms2HZUp5BUwJJ+w3YEiyi4Vrcc2x0L+Yg1HWOGCoc/FM3VMgeE3fF22Gs+E6dxiskPn9QgcoNOJDqdAmlRSgg==",
+      "dev": true,
+      "requires": {
+        "jsx-ast-utils": "^2.4.1"
+      },
+      "dependencies": {
+        "jsx-ast-utils": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-2.4.1.tgz",
+          "integrity": "sha512-z1xSldJ6imESSzOjd3NNkieVJKRlKYSOtMG8SFyCj2FIrvSaSuli/WjpBkEzCBoR9bYYYFgqJw61Xhu7Lcgk+w==",
+          "dev": true,
+          "requires": {
+            "array-includes": "^3.1.1",
+            "object.assign": "^4.1.0"
+          }
+        }
+      }
+    },
+    "@next/eslint-plugin-next": {
+      "version": "12.0.7",
+      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-12.0.7.tgz",
+      "integrity": "sha512-xk7eMjw4+roWWR/0ETIoToCNs2wdvCGgQUiUO390Rj33/82yxZsh+ODRSaFWkiKp8zHWQN5GCW+U5pfjt/gyQg==",
+      "dev": true,
+      "requires": {
+        "glob": "7.1.7"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "7.1.7",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
+          "integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        }
+      }
+    },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -5014,9 +5119,9 @@
       "peer": true
     },
     "@types/node": {
-      "version": "16.11.6",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.6.tgz",
-      "integrity": "sha512-ua7PgUoeQFjmWPcoo9khiPum3Pd60k4/2ZGXt18sm2Slk0W0xZTqt5Y0Ny1NyBiN1EVQ/+FaF9NcY4Qe6rwk5w==",
+      "version": "16.11.17",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.17.tgz",
+      "integrity": "sha512-C1vTZME8cFo8uxY2ui41xcynEotVkczIVI5AjLmy5pkpBv/FtG+jhtOlfcPysI8VRVwoOMv6NJm44LGnoMSWkw==",
       "dev": true
     },
     "@types/normalize-package-data": {
@@ -5381,6 +5486,12 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
     },
+    "colord": {
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/colord/-/colord-2.9.2.tgz",
+      "integrity": "sha512-Uqbg+J445nc1TKn4FoDPS6ZZqAvEDnwrH42yo8B40JSOgSLxMZ/gt3h4nmCtPLQeXhjJJkqBx7SCY35WnIixaQ==",
+      "peer": true
+    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -5437,9 +5548,9 @@
       "dev": true
     },
     "debug": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
-      "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
+      "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
       "requires": {
         "ms": "2.1.2"
       }
@@ -5873,9 +5984,9 @@
       }
     },
     "eslint-plugin-prettier": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-3.4.1.tgz",
-      "integrity": "sha512-htg25EUYUeIhKHXjOinK4BgCcDwtLHjqaxCDsMy5nbnUMkKFvIhMVCp+5GFUXQ4Nr8lBsPqtGAqBenbpFqAA2g==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-4.0.0.tgz",
+      "integrity": "sha512-98MqmCJ7vJodoQK359bqQWaxOE0CS8paAz/GgjaZLyex4TTk3g9HugoO89EqWCrFiOqn9EVvcoo7gZzONCWVwQ==",
       "dev": true,
       "requires": {
         "prettier-linter-helpers": "^1.0.0"
@@ -6637,9 +6748,9 @@
       "peer": true
     },
     "known-css-properties": {
-      "version": "0.23.0",
-      "resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.23.0.tgz",
-      "integrity": "sha512-h9ivI88e1lFNmTT4HovBN33Ysn0OIJG7IPG2mkpx2uniQXFWqo35QdiX7w0TovlUFXfW8aPFblP5/q0jlOr2sA==",
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.24.0.tgz",
+      "integrity": "sha512-RTSoaUAfLvpR357vWzAz/50Q/BmHfmE6ETSWfutT0AJiw10e6CmcdYRQJlLRd95B53D0Y2aD1jSxD3V3ySF+PA==",
       "peer": true
     },
     "language-subtag-registry": {
@@ -6682,11 +6793,6 @@
         "p-locate": "^2.0.0",
         "path-exists": "^3.0.0"
       }
-    },
-    "lodash.clonedeep": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
-      "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8="
     },
     "lodash.merge": {
       "version": "4.6.2",
@@ -7030,13 +7136,13 @@
       }
     },
     "postcss": {
-      "version": "8.3.11",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.3.11.tgz",
-      "integrity": "sha512-hCmlUAIlUiav8Xdqw3Io4LcpA1DOt7h3LSTAC4G6JGHFFaWzI6qvFt9oilvl8BmkbBRX1IhM90ZAmpk68zccQA==",
+      "version": "8.4.5",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.5.tgz",
+      "integrity": "sha512-jBDboWM8qpaqwkMwItqTQTiFikhs/67OYVvblFFTM7MrZjt6yMKd6r2kgXizEbTTljacm4NldIlZnhbjr84QYg==",
       "requires": {
         "nanoid": "^3.1.30",
         "picocolors": "^1.0.0",
-        "source-map-js": "^0.6.2"
+        "source-map-js": "^1.0.1"
       }
     },
     "postcss-media-query-parser": {
@@ -7059,9 +7165,9 @@
       "requires": {}
     },
     "postcss-selector-parser": {
-      "version": "6.0.6",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.6.tgz",
-      "integrity": "sha512-9LXrvaaX3+mcv5xkg5kFwqSzSH1JIObIx51PrndZwlmznwXRfxMddDvo9gve3gVR8ZTKgoFDdWkbRFmEhT4PMg==",
+      "version": "6.0.8",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.8.tgz",
+      "integrity": "sha512-D5PG53d209Z1Uhcc0qAZ5U3t5HagH3cxu+WLZ22jt3gLUpXM4eXXfiO14jiDWST3NNooX/E8wISfOhZ9eIjGTQ==",
       "peer": true,
       "requires": {
         "cssesc": "^3.0.0",
@@ -7078,7 +7184,6 @@
       "version": "0.36.2",
       "resolved": "https://registry.npmjs.org/postcss-syntax/-/postcss-syntax-0.36.2.tgz",
       "integrity": "sha512-nBRg/i7E3SOHWxF3PpF5WnJM/jQ1YpY9000OaVXlAQj6Zp/kIqJxEDWIZ67tAd7NLuk7zqN4yqe9nc0oNAOs1w==",
-      "peer": true,
       "requires": {}
     },
     "postcss-value-parser": {
@@ -7094,9 +7199,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.4.1.tgz",
-      "integrity": "sha512-9fbDAXSBcc6Bs1mZrDYb3XKzDLm4EXXL9sC1LqKP5rZkT6KRr/rf9amVUcODVXgguK/isJz0d0hP72WeaKWsvA==",
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.5.1.tgz",
+      "integrity": "sha512-vBZcPRUR5MZJwoyi3ZoyQlc1rXeEck8KgeC9AwwOn+exuxLxq5toTRDTSaVrXHxelDMHy9zlicw8u66yxoSUFg==",
       "dev": true
     },
     "prettier-linter-helpers": {
@@ -7417,9 +7522,9 @@
       "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
     },
     "source-map-js": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-0.6.2.tgz",
-      "integrity": "sha512-/3GptzWzu0+0MBQFrDKzw/DvvMTUORvgY6k6jd/VS6iCR4RDTKWH6v6WPwQoUO8667uQEf9Oe38DxAYWY5F/Ug=="
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.1.tgz",
+      "integrity": "sha512-4+TN2b3tqOCd/kaGRJ/sTYA0tR0mdXx26ipdolxcwtJVqEnqNYvlCAt1q3ypy4QMlYus+Zh34RNtYLoq2oQ4IA=="
     },
     "spdx-correct": {
       "version": "3.1.1",
@@ -7554,14 +7659,15 @@
       "peer": true
     },
     "stylelint": {
-      "version": "14.0.1",
-      "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-14.0.1.tgz",
-      "integrity": "sha512-ZcAkmFLVCultmwkQUjxKzxW/o5+CzNmDk6TPJj/d4Y7ipTGGrewIWmNm+InjdSr04PR5/yynsAJeYJY/wisdMg==",
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-14.2.0.tgz",
+      "integrity": "sha512-i0DrmDXFNpDsWiwx6SPRs4/pyw4kvZgqpDGvsTslQMY7hpUl6r33aQvNSn6cnTg2wtZ9rreFElI7XAKpOWi1vQ==",
       "peer": true,
       "requires": {
         "balanced-match": "^2.0.0",
+        "colord": "^2.9.2",
         "cosmiconfig": "^7.0.1",
-        "debug": "^4.3.2",
+        "debug": "^4.3.3",
         "execall": "^2.0.0",
         "fast-glob": "^3.2.7",
         "fastest-levenshtein": "^1.0.12",
@@ -7571,11 +7677,11 @@
         "globby": "^11.0.4",
         "globjoin": "^0.1.4",
         "html-tags": "^3.1.0",
-        "ignore": "^5.1.8",
+        "ignore": "^5.2.0",
         "import-lazy": "^4.0.0",
         "imurmurhash": "^0.1.4",
         "is-plain-object": "^5.0.0",
-        "known-css-properties": "^0.23.0",
+        "known-css-properties": "^0.24.0",
         "mathml-tag-names": "^2.1.3",
         "meow": "^9.0.0",
         "micromatch": "^4.0.4",
@@ -7586,7 +7692,7 @@
         "postcss-media-query-parser": "^0.2.3",
         "postcss-resolve-nested-selector": "^0.1.1",
         "postcss-safe-parser": "^6.0.0",
-        "postcss-selector-parser": "^6.0.6",
+        "postcss-selector-parser": "^6.0.7",
         "postcss-value-parser": "^4.1.0",
         "resolve-from": "^5.0.0",
         "specificity": "^0.4.1",
@@ -7594,7 +7700,7 @@
         "strip-ansi": "^6.0.1",
         "style-search": "^0.1.0",
         "svg-tags": "^1.0.0",
-        "table": "^6.7.2",
+        "table": "^6.7.5",
         "v8-compile-cache": "^2.3.0",
         "write-file-atomic": "^3.0.3"
       },
@@ -7606,9 +7712,9 @@
           "peer": true
         },
         "ignore": {
-          "version": "5.1.8",
-          "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
-          "integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==",
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
+          "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
           "peer": true
         },
         "resolve-from": {
@@ -7632,9 +7738,9 @@
       "requires": {}
     },
     "stylelint-config-standard": {
-      "version": "23.0.0",
-      "resolved": "https://registry.npmjs.org/stylelint-config-standard/-/stylelint-config-standard-23.0.0.tgz",
-      "integrity": "sha512-8PDlk+nWuc1T66nVaODTdVodN0pjuE5TBlopi39Lt9EM36YJsRhqttMyUhnS78oc/59Q6n8iw2GJB4QcoFqtRg==",
+      "version": "24.0.0",
+      "resolved": "https://registry.npmjs.org/stylelint-config-standard/-/stylelint-config-standard-24.0.0.tgz",
+      "integrity": "sha512-+RtU7fbNT+VlNbdXJvnjc3USNPZRiRVp/d2DxOF/vBDDTi0kH5RX2Ny6errdtZJH3boO+bmqIYEllEmok4jiuw==",
       "requires": {
         "stylelint-config-recommended": "^6.0.0"
       }
@@ -7663,12 +7769,11 @@
       "peer": true
     },
     "table": {
-      "version": "6.7.2",
-      "resolved": "https://registry.npmjs.org/table/-/table-6.7.2.tgz",
-      "integrity": "sha512-UFZK67uvyNivLeQbVtkiUs8Uuuxv24aSL4/Vil2PJVtMgU8Lx0CYkP12uCGa3kjyQzOSgV1+z9Wkb82fCGsO0g==",
+      "version": "6.7.5",
+      "resolved": "https://registry.npmjs.org/table/-/table-6.7.5.tgz",
+      "integrity": "sha512-LFNeryOqiQHqCVKzhkymKwt6ozeRhlm8IL1mE8rNUurkir4heF6PzMyRgaTa4tlyPTGGgXuvVOF/OLWiH09Lqw==",
       "requires": {
         "ajv": "^8.0.1",
-        "lodash.clonedeep": "^4.5.0",
         "lodash.truncate": "^4.4.2",
         "slice-ansi": "^4.0.0",
         "string-width": "^4.2.3",

--- a/package.json
+++ b/package.json
@@ -16,17 +16,19 @@
   },
   "dependencies": {
     "@stylelint/postcss-css-in-js": "^0.37.2",
+    "postcss": "^8.4.5",
+    "postcss-syntax": "^0.36.2",
     "stylelint-config-prettier": "^9.0.3",
-    "stylelint-config-standard": "^23.0.0",
+    "stylelint-config-standard": "^24.0.0",
     "stylelint-order": "^5.0.0"
   },
   "devDependencies": {
-    "@asl-19/eslint-config": "^0.4.0",
-    "@types/node": "^16.11.6",
+    "@asl-19/eslint-config": "^0.5.0",
+    "@types/node": "^16.11.17",
     "eslint": "^7.32.0",
-    "prettier": "^2.4.1"
+    "prettier": "^2.5.1"
   },
   "peerDependencies": {
-    "stylelint": "^14.0.1"
+    "stylelint": "^14.2.0"
   }
 }


### PR DESCRIPTION
We need these meet @stylelint/postcss-css-in-js peer dependencies.

Also upgrade other dependencies.

Closes #29